### PR TITLE
allow TOOLCHAIN_VERSION to be overridden

### DIFF
--- a/build-droid/build-all.sh
+++ b/build-droid/build-all.sh
@@ -89,7 +89,11 @@ pushd $TMPDIR
 
 export ANDROID_API_LEVEL="14"
 export ARM_TARGET="armv7"
-export TOOLCHAIN_VERSION="4.7"
+
+if [ -z $TOOLCHAIN_VERSION ]
+then
+	export TOOLCHAIN_VERSION="4.7"
+fi
 
 # Platforms to build for (changing this may break the build)
 PLATFORMS="arm-linux-androideabi"


### PR DESCRIPTION
If we could override TOOLCHAIN_VERSION, we would be able to use older NDKs.  I've patched build-droid/build-all.sh to allow for this.  It of course still defaults to 4.7.

Using r7c would look like this, for example:

```
$ TOOLCHAIN_VERSION=4.4.3 ./build-all.sh /foo/bar//android-ndk-r7c
```
