### PR TITLE
make ios build more like android build

### DIFF
--- a/build-droid/build-all.sh
+++ b/build-droid/build-all.sh
@@ -51,6 +51,7 @@ export LIBGSASL_VERSION="1.8.0"
 
 # Project version to use to build boost C++ libraries
 export BOOST_VERSION="1.52.0"
+export BOOST_LIBS="date_time filesystem program_options regex signals system thread iostreams"
 
 # Project version to use to build tinyxml
 export TINYXML_VERSION="2.6.2"

--- a/build-droid/build-boost.sh
+++ b/build-droid/build-boost.sh
@@ -55,9 +55,9 @@ tar xvf "${TOPDIR}/build-droid/droid-boost-patch.tar.gz"
 # ---------
 
 # Make the initial bootstrap
-echo "Performing boost boostrap"
-
-./bootstrap.sh
+BOOST_LIBS_COMMA=$(echo $BOOST_LIBS | sed -e "s/ /,/g")
+echo "Bootstrapping (with libs $BOOST_LIBS_COMMA)"
+./bootstrap.sh --with-libraries=$BOOST_LIBS_COMMA
 if [ $? != 0 ] ; then
 	echo "ERROR: Could not perform boostrap! See $TMPLOG for more info."
 	exit 1

--- a/build-droid/build-boost.sh
+++ b/build-droid/build-boost.sh
@@ -183,8 +183,6 @@ using android : arm : ${DROIDTOOLS}-g++ :
 EOF
 
 cat >> project-config.jam <<EOF
-libraries = --with-date_time --with-filesystem --with-program_options --with-regex --with-signals --with-system --with-thread --with-iostreams ;
-
 option.set prefix : ${ROOTDIR}/ ;
 option.set exec-prefix : ${ROOTDIR}/bin ;
 option.set libdir : ${ROOTDIR}/lib ;

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -149,61 +149,61 @@ do
 	export RANLIB="${DEVROOT}/usr/bin/ranlib"
 
 	# Build minizip
-	${TOPDIR}/build-ios/build-minizip.sh > "${LOGPATH}-minizip.log"
+	# ${TOPDIR}/build-ios/build-minizip.sh > "${LOGPATH}-minizip.log"
 
 	# Build icu
-	${TOPDIR}/build-ios/build-icu.sh > "${LOGPATH}-icu.log"
+	# ${TOPDIR}/build-ios/build-icu.sh > "${LOGPATH}-icu.log"
 
 	# Build c-ares
-	${TOPDIR}/build-ios/build-cares.sh > "${LOGPATH}-cares.log"
+	# ${TOPDIR}/build-ios/build-cares.sh > "${LOGPATH}-cares.log"
 
 	# Build bzip2
-	${TOPDIR}/build-ios/build-bzip2.sh > "${LOGPATH}-bzip2.log"
+	# ${TOPDIR}/build-ios/build-bzip2.sh > "${LOGPATH}-bzip2.log"
 
 	# Build libidn (before curl and gsasl)
-	${TOPDIR}/build-ios/build-libidn.sh > "${LOGPATH}-libidn.log"
+	# ${TOPDIR}/build-ios/build-libidn.sh > "${LOGPATH}-libidn.log"
 
 	# Build libgpg-error
-	${TOPDIR}/build-ios/build-libgpg-error.sh > "${LOGPATH}-libgpg-error.log"
+	# ${TOPDIR}/build-ios/build-libgpg-error.sh > "${LOGPATH}-libgpg-error.log"
 
 	# Build libgcrypt
-	${TOPDIR}/build-ios/build-libgcrypt.sh > "${LOGPATH}-libgcrypt.log"
+	# ${TOPDIR}/build-ios/build-libgcrypt.sh > "${LOGPATH}-libgcrypt.log"
 
 	# Build GnuPG
-	${TOPDIR}/build-ios/build-GnuPG.sh > "${LOGPATH}-GnuPG.log"
+	# ${TOPDIR}/build-ios/build-GnuPG.sh > "${LOGPATH}-GnuPG.log"
 
 	# Build OpenSSL
-	${TOPDIR}/build-ios/build-openssl.sh > "${LOGPATH}-OpenSSL.log"
+	# ${TOPDIR}/build-ios/build-openssl.sh > "${LOGPATH}-OpenSSL.log"
 
 	# Build libssh2
-	${TOPDIR}/build-ios/build-libssh2.sh > "${LOGPATH}-libssh2.log"
+	# ${TOPDIR}/build-ios/build-libssh2.sh > "${LOGPATH}-libssh2.log"
 
 	# Build cURL
-	${TOPDIR}/build-ios/build-cURL.sh > "${LOGPATH}-cURL.log"
+	# ${TOPDIR}/build-ios/build-cURL.sh > "${LOGPATH}-cURL.log"
 
 	# Build libgsasl
-	${TOPDIR}/build-ios/build-libgsasl.sh > "${LOGPATH}-libgsasl.log"
+	# ${TOPDIR}/build-ios/build-libgsasl.sh > "${LOGPATH}-libgsasl.log"
 
     # Build BOOST
     ${TOPDIR}/build-ios/build-boost.sh > "${LOGPATH}-boost.log"
 
 	# Build tinyxml
-	${TOPDIR}/build-ios/build-tinyxml.sh > "${LOGPATH}-tinyxml.log"
+	# ${TOPDIR}/build-ios/build-tinyxml.sh > "${LOGPATH}-tinyxml.log"
 
 	# Build expat
-	${TOPDIR}/build-ios/build-expat.sh > "${LOGPATH}-expat.log"
+	# ${TOPDIR}/build-ios/build-expat.sh > "${LOGPATH}-expat.log"
 
 	# Build yajl
-	${TOPDIR}/build-ios/build-yajl.sh > "${LOGPATH}-yajl.log"
+	# ${TOPDIR}/build-ios/build-yajl.sh > "${LOGPATH}-yajl.log"
 
 	# Build SQLCipher
-	${TOPDIR}/build-ios/build-sqlcipher.sh > "${LOGPATH}-sqlcipher.log"
+	# ${TOPDIR}/build-ios/build-sqlcipher.sh > "${LOGPATH}-sqlcipher.log"
 
 	# Build SOCI
-	${TOPDIR}/build-ios/build-soci.sh > "${LOGPATH}-soci.log"
+	# ${TOPDIR}/build-ios/build-soci.sh > "${LOGPATH}-soci.log"
 
 	# Build PION
-	${TOPDIR}/build-ios/build-pion.sh > "${LOGPATH}-pion.log"
+	# ${TOPDIR}/build-ios/build-pion.sh > "${LOGPATH}-pion.log"
 
 	# Remove junk
 	rm -rf "${ROOTDIR}/bin"

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -149,61 +149,61 @@ do
 	export RANLIB="${DEVROOT}/usr/bin/ranlib"
 
 	# Build minizip
-	# ${TOPDIR}/build-ios/build-minizip.sh > "${LOGPATH}-minizip.log"
+	${TOPDIR}/build-ios/build-minizip.sh > "${LOGPATH}-minizip.log"
 
 	# Build icu
-	# ${TOPDIR}/build-ios/build-icu.sh > "${LOGPATH}-icu.log"
+	${TOPDIR}/build-ios/build-icu.sh > "${LOGPATH}-icu.log"
 
 	# Build c-ares
-	# ${TOPDIR}/build-ios/build-cares.sh > "${LOGPATH}-cares.log"
+	${TOPDIR}/build-ios/build-cares.sh > "${LOGPATH}-cares.log"
 
 	# Build bzip2
-	# ${TOPDIR}/build-ios/build-bzip2.sh > "${LOGPATH}-bzip2.log"
+	${TOPDIR}/build-ios/build-bzip2.sh > "${LOGPATH}-bzip2.log"
 
 	# Build libidn (before curl and gsasl)
-	# ${TOPDIR}/build-ios/build-libidn.sh > "${LOGPATH}-libidn.log"
+	${TOPDIR}/build-ios/build-libidn.sh > "${LOGPATH}-libidn.log"
 
 	# Build libgpg-error
-	# ${TOPDIR}/build-ios/build-libgpg-error.sh > "${LOGPATH}-libgpg-error.log"
+	${TOPDIR}/build-ios/build-libgpg-error.sh > "${LOGPATH}-libgpg-error.log"
 
 	# Build libgcrypt
-	# ${TOPDIR}/build-ios/build-libgcrypt.sh > "${LOGPATH}-libgcrypt.log"
+	${TOPDIR}/build-ios/build-libgcrypt.sh > "${LOGPATH}-libgcrypt.log"
 
 	# Build GnuPG
-	# ${TOPDIR}/build-ios/build-GnuPG.sh > "${LOGPATH}-GnuPG.log"
+	${TOPDIR}/build-ios/build-GnuPG.sh > "${LOGPATH}-GnuPG.log"
 
 	# Build OpenSSL
-	# ${TOPDIR}/build-ios/build-openssl.sh > "${LOGPATH}-OpenSSL.log"
+	${TOPDIR}/build-ios/build-openssl.sh > "${LOGPATH}-OpenSSL.log"
 
 	# Build libssh2
-	# ${TOPDIR}/build-ios/build-libssh2.sh > "${LOGPATH}-libssh2.log"
+	${TOPDIR}/build-ios/build-libssh2.sh > "${LOGPATH}-libssh2.log"
 
 	# Build cURL
-	# ${TOPDIR}/build-ios/build-cURL.sh > "${LOGPATH}-cURL.log"
+	${TOPDIR}/build-ios/build-cURL.sh > "${LOGPATH}-cURL.log"
 
 	# Build libgsasl
-	# ${TOPDIR}/build-ios/build-libgsasl.sh > "${LOGPATH}-libgsasl.log"
+	${TOPDIR}/build-ios/build-libgsasl.sh > "${LOGPATH}-libgsasl.log"
 
     # Build BOOST
     ${TOPDIR}/build-ios/build-boost.sh > "${LOGPATH}-boost.log"
 
 	# Build tinyxml
-	# ${TOPDIR}/build-ios/build-tinyxml.sh > "${LOGPATH}-tinyxml.log"
+	${TOPDIR}/build-ios/build-tinyxml.sh > "${LOGPATH}-tinyxml.log"
 
 	# Build expat
-	# ${TOPDIR}/build-ios/build-expat.sh > "${LOGPATH}-expat.log"
+	${TOPDIR}/build-ios/build-expat.sh > "${LOGPATH}-expat.log"
 
 	# Build yajl
-	# ${TOPDIR}/build-ios/build-yajl.sh > "${LOGPATH}-yajl.log"
+	${TOPDIR}/build-ios/build-yajl.sh > "${LOGPATH}-yajl.log"
 
 	# Build SQLCipher
-	# ${TOPDIR}/build-ios/build-sqlcipher.sh > "${LOGPATH}-sqlcipher.log"
+	${TOPDIR}/build-ios/build-sqlcipher.sh > "${LOGPATH}-sqlcipher.log"
 
 	# Build SOCI
-	# ${TOPDIR}/build-ios/build-soci.sh > "${LOGPATH}-soci.log"
+	${TOPDIR}/build-ios/build-soci.sh > "${LOGPATH}-soci.log"
 
 	# Build PION
-	# ${TOPDIR}/build-ios/build-pion.sh > "${LOGPATH}-pion.log"
+	${TOPDIR}/build-ios/build-pion.sh > "${LOGPATH}-pion.log"
 
 	# Remove junk
 	rm -rf "${ROOTDIR}/bin"

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -103,9 +103,6 @@ do
 	mkdir -p "${ROOTDIR}"
 done
 
-# Build BOOST
-${TOPDIR}/build-ios/build-boost.sh > "${LOGDIR}/boost.log"
-
 for PLATFORM in ${PLATFORMS}
 do
 	LOGPATH="${LOGDIR}/${PLATFORM}"
@@ -186,6 +183,9 @@ do
 
 	# Build libgsasl
 	${TOPDIR}/build-ios/build-libgsasl.sh > "${LOGPATH}-libgsasl.log"
+
+    # Build BOOST
+    ${TOPDIR}/build-ios/build-boost.sh > "${LOGPATH}-boost.log"
 
 	# Build tinyxml
 	${TOPDIR}/build-ios/build-tinyxml.sh > "${LOGPATH}-tinyxml.log"

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -218,10 +218,6 @@ do
 
 done
 
-# Remove individual boost libraries as all were combined into one 
-# libboost.a (comment this line if individual libraries are required)
-find ${TMPDIR}/build/ios -name "libboost_*.*" -exec rm -f {} \;
-
 # Create Lipo Archives and Framework bundle
 
 DEVROOT=${DEVELOPER}/Platforms/iPhoneOS.platform/Developer

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -51,6 +51,7 @@ export LIBGSASL_VERSION="1.8.0"
 
 # Project version to use to build boost C++ libraries
 export BOOST_VERSION="1.52.0"
+export BOOST_LIBS="date_time filesystem program_options regex signals system thread iostreams"
 
 # Project version to use to build tinyxml
 export TINYXML_VERSION="2.6.2"

--- a/build-ios/build-boost.sh
+++ b/build-ios/build-boost.sh
@@ -87,10 +87,10 @@ echo
 # boost needs its own versions of some values
 if [ "${PLATFORM}" == "iPhoneSimulator" ]
 then
-    BOOST_TOOL="iphonesim"
+    BOOST_PLAT="iphonesim"
     BOOST_ARCH="x86"
 else
-    BOOST_TOOL="iphone"
+    BOOST_PLAT="iphone"
     BOOST_ARCH="arm"
 fi
 
@@ -145,7 +145,7 @@ writeBjamUserConfig()
     echo Writing usr-config
 
     cat >> tools/build/v2/user-config.jam <<EOF
-using darwin : ${SDK}~${BOOST_TOOL}
+using darwin : ${SDK}~${BOOST_PLAT}
    : ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/usr/bin/gcc -arch $ARCH -mthumb -fvisibility=hidden -fvisibility-inlines-hidden $EXTRA_CPPFLAGS
    : 
    : <architecture>$BOOST_ARCH <target-os>iphone
@@ -179,7 +179,7 @@ bootstrapBoost()
 
 buildBoostForiPhoneOS()
 {
-    ./bjam --prefix="$ROOTDIR" toolset=darwin architecture=$BOOST_ARCH target-os=iphone macosx-version=${BOOST_TOOL}-${IPHONE_SDKVERSION} define=_LITTLE_ENDIAN link=static install
+    ./bjam --prefix="$ROOTDIR" toolset=darwin architecture=$BOOST_ARCH target-os=iphone macosx-version=${BOOST_PLAT}-${IPHONE_SDKVERSION} define=_LITTLE_ENDIAN link=static install
     doneSection
 }
 

--- a/build-ios/build-boost.sh
+++ b/build-ios/build-boost.sh
@@ -70,7 +70,6 @@ fi
 
 : ${TARBALLDIR:=`pwd`}
 : ${SRCDIR:=`pwd`/boost/src}
-: ${BUILDDIR:=`pwd`/boost/build}
 : ${PREFIXDIR:=`pwd`/boost/prefix}
 
 BOOST_TARBALL=$TARBALLDIR/${BOOST_SOURCE_NAME}.tar.gz
@@ -78,11 +77,7 @@ BOOST_SRC=$SRCDIR/${BOOST_SOURCE_NAME}
 
 #===============================================================================
 
-ARM_DEV_DIR=${DEVELOPER}/Platforms/iPhoneOS.platform/Developer/usr/bin/
-SIM_DEV_DIR=${DEVELOPER}/Platforms/iPhoneSimulator.platform/Developer/usr/bin/
-
-ARM_COMBINED_LIB=$BUILDDIR/lib_boost_arm.a
-SIM_COMBINED_LIB=$BUILDDIR/lib_boost_x86.a
+DEV_DIR=${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/usr/bin/
 
 #===============================================================================
 
@@ -90,10 +85,19 @@ echo "BOOST_VERSION:     $BOOST_VERSION"
 echo "BOOST_LIBS:        $BOOST_LIBS"
 echo "BOOST_TARBALL:     $BOOST_TARBALL"
 echo "BOOST_SRC:         $BOOST_SRC"
-echo "BUILDDIR:          $BUILDDIR"
 echo "PREFIXDIR:         $PREFIXDIR"
 echo "IPHONE_SDKVERSION: $IPHONE_SDKVERSION"
 echo
+
+# boost needs its own versions of some values
+if [ "${PLATFORM}" == "iPhoneSimulator" ]
+then
+    BOOST_TOOL="iphonesim"
+    BOOST_ARCH="x86"
+else
+    BOOST_TOOL="iphone"
+    BOOST_ARCH="arm"
+fi
 
 #===============================================================================
 # Functions
@@ -120,7 +124,6 @@ cleanEverythingReadyToStart()
 {
     echo Cleaning everything before we start to build...
     rm -rf $BOOST_SRC
-    rm -rf $BUILDDIR
     rm -rf $PREFIXDIR
     doneSection
 }
@@ -142,18 +145,12 @@ writeBjamUserConfig()
     # You need to do this to point bjam at the right compiler
     # ONLY SEEMS TO WORK IN HOME DIR GRR
     echo Writing usr-config
-    #mkdir -p $BUILDDIR
-    #cat > ~/user-config.jam <<EOF
+  
     cat >> $BOOST_SRC/tools/build/v2/user-config.jam <<EOF
-using darwin : ${SDK}~iphone
-   : ${DEVELOPER}/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc -arch armv7 -mthumb -fvisibility=hidden -fvisibility-inlines-hidden $EXTRA_CPPFLAGS
-   : <striper>
-   : <architecture>arm <target-os>iphone
-   ;
-using darwin : ${SDK}~iphonesim
-   : ${DEVELOPER}/Platforms/iPhoneSimulator.platform/Developer/usr/bin/gcc -arch i386 -fvisibility=hidden -fvisibility-inlines-hidden $EXTRA_CPPFLAGS
-   : <striper>
-   : <architecture>x86 <target-os>iphone
+using darwin : ${SDK}~${BOOST_TOOL}
+   : ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/usr/bin/gcc -arch $ARCH -mthumb -fvisibility=hidden -fvisibility-inlines-hidden $EXTRA_CPPFLAGS
+   : 
+   : <architecture>$BOOST_ARCH <target-os>iphone
    ;
 EOF
     doneSection
@@ -187,67 +184,31 @@ buildBoostForiPhoneOS()
 {
     cd $BOOST_SRC
 
-    ./bjam --prefix="$PREFIXDIR" toolset=darwin architecture=arm target-os=iphone macosx-version=iphone-${IPHONE_SDKVERSION} define=_LITTLE_ENDIAN link=static install
-    doneSection
-
-    ./bjam toolset=darwin architecture=x86 target-os=iphone macosx-version=iphonesim-${IPHONE_SDKVERSION} link=static stage
+    ./bjam --prefix="$ROOTDIR" toolset=darwin architecture=$BOOST_ARCH target-os=iphone macosx-version=${BOOST_TOOL}-${IPHONE_SDKVERSION} define=_LITTLE_ENDIAN link=static install
     doneSection
 }
 
 #===============================================================================
 
-scrunchAllLibsTogetherInOneLibPerPlatform()
+scrunchAllLibsTogetherInOneLib()
 {
-    ALL_LIBS_ARM=""
-    ALL_LIBS_SIM=""
-    for NAME in $BOOST_LIBS; do
-        ALL_LIBS_ARM="$ALL_LIBS_ARM $BOOST_SRC/bin.v2/libs/$NAME/build/darwin-${SDK}~iphone/release/architecture-arm/link-static/macosx-version-iphone-$IPHONE_SDKVERSION/target-os-iphone/threading-multi/libboost_$NAME.a";
-        ALL_LIBS_SIM="$ALL_LIBS_SIM $BOOST_SRC/bin.v2/libs/$NAME/build/darwin-${SDK}~iphonesim/release/architecture-x86/link-static/macosx-version-iphonesim-$IPHONE_SDKVERSION/target-os-iphone/threading-multi/libboost_$NAME.a";
+    OBJDIR=$BOOST_SRC/tmp/obj
+    mkdir -p $OBJDIR
+    for a in $ROOTDIR/lib/libboost_*.a; do
+    
+        # telling bjam to make armv7 always makes fat arm6/7 binaries (ug); we need to thin it to just the arch we want    
+        if [ "${ARCH}" == "armv7" ]
+        then
+            echo thining $a...
+            lipo -thin $ARCH $a -output $a
+        fi    
+
+        echo Decomposing $a...
+        (cd $OBJDIR; ${DEV_DIR}/ar -x $a );
     done;
 
-    mkdir -p $BUILDDIR/armv6/obj
-    mkdir -p $BUILDDIR/armv7/obj
-    mkdir -p $BUILDDIR/i386/obj
-
-    mkdir -p ${TMPDIR}/build/ios/iPhoneOS-V6/lib
-    mkdir -p ${TMPDIR}/build/ios/iPhoneOS-V7/lib
-    mkdir -p ${TMPDIR}/build/ios/iPhoneSimulator/lib
-
-    ALL_LIBS=""
-
-    echo Splitting all existing fat binaries...
-    for NAME in $BOOST_LIBS; do
-        ALL_LIBS="$ALL_LIBS libboost_$NAME.a"
-        lipo "$BOOST_SRC/bin.v2/libs/$NAME/build/darwin-${SDK}~iphone/release/architecture-arm/link-static/macosx-version-iphone-$IPHONE_SDKVERSION/target-os-iphone/threading-multi/libboost_$NAME.a" -thin armv6 -o $BUILDDIR/armv6/libboost_$NAME.a
-        lipo "$BOOST_SRC/bin.v2/libs/$NAME/build/darwin-${SDK}~iphone/release/architecture-arm/link-static/macosx-version-iphone-$IPHONE_SDKVERSION/target-os-iphone/threading-multi/libboost_$NAME.a" -thin armv7 -o $BUILDDIR/armv7/libboost_$NAME.a
-        cp "$BOOST_SRC/bin.v2/libs/$NAME/build/darwin-${SDK}~iphonesim/release/architecture-x86/link-static/macosx-version-iphonesim-$IPHONE_SDKVERSION/target-os-iphone/threading-multi/libboost_$NAME.a" $BUILDDIR/i386/libboost_$NAME.a
-
-        cp $BUILDDIR/armv6/libboost_$NAME.a ${TMPDIR}/build/ios/iPhoneOS-V6/lib
-        cp $BUILDDIR/armv7/libboost_$NAME.a ${TMPDIR}/build/ios/iPhoneOS-V7/lib
-        cp $BUILDDIR/i386/libboost_$NAME.a ${TMPDIR}/build/ios/iPhoneSimulator/lib
-    done
-
-    echo "Decomposing each architecture's .a files"
-    for NAME in $ALL_LIBS; do
-        echo Decomposing $NAME...
-        (cd $BUILDDIR/armv6/obj; ar -x ../$NAME );
-        (cd $BUILDDIR/armv7/obj; ar -x ../$NAME );
-        (cd $BUILDDIR/i386/obj; ar -x ../$NAME );
-    done
-
-    echo "Linking each architecture into an uberlib ($ALL_LIBS => libboost.a )"
-    rm -f ${TMPDIR}/build/ios/*/lib/libboost.a
-    echo ...armv6
-    (cd $BUILDDIR/armv6; $ARM_DEV_DIR/ar crus ${TMPDIR}/build/ios/iPhoneOS-V6/lib/libboost.a obj/*.o; )
-    echo ...armv7
-    (cd $BUILDDIR/armv7; $ARM_DEV_DIR/ar crus ${TMPDIR}/build/ios/iPhoneOS-V7/lib/libboost.a obj/*.o; )
-    echo ...i386
-    (cd $BUILDDIR/i386;  $SIM_DEV_DIR/ar crus ${TMPDIR}/build/ios/iPhoneSimulator/lib/libboost.a obj/*.o; )
-
-    echo "Copying header files"
-    cp -r ${PREFIXDIR}/include ${TMPDIR}/build/ios/iPhoneOS-V6
-    cp -r ${PREFIXDIR}/include ${TMPDIR}/build/ios/iPhoneOS-V7
-    cp -r ${PREFIXDIR}/include ${TMPDIR}/build/ios/iPhoneSimulator
+    echo creating $ROOTDIR/lib/libboost.a
+    (cd $OBJDIR; ${DEV_DIR}/ar crus $ROOTDIR/lib/libboost.a *.o; )
 }
 
 #===============================================================================
@@ -256,15 +217,13 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
 [ -f "$BOOST_TARBALL" ] || abort "Source tarball missing."
 
-mkdir -p $BUILDDIR
-
 cleanEverythingReadyToStart
 unpackBoost
 inventMissingHeaders
-writeBjamUserConfig
 bootstrapBoost
+writeBjamUserConfig
 buildBoostForiPhoneOS
-scrunchAllLibsTogetherInOneLibPerPlatform
+scrunchAllLibsTogetherInOneLib
 
 echo "Completed successfully"
 

--- a/build-ios/build-boost.sh
+++ b/build-ios/build-boost.sh
@@ -58,7 +58,6 @@ fi
 #===============================================================================
 
 : ${IPHONE_SDKVERSION:=${SDK}}
-: ${BOOST_LIBS:="date_time filesystem program_options regex signals system thread iostreams"}
 : ${EXTRA_CPPFLAGS:="-Os -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS"}
 
 # The EXTRA_CPPFLAGS definition works around a thread race issue in

--- a/build-ios/build-icu.sh
+++ b/build-ios/build-icu.sh
@@ -57,9 +57,9 @@ export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 
 pushd "icu/source"
-./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-cross-build="${HOSTBUILD}" --enable-static --disable-shared
+./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-cross-build="${HOSTBUILD}" --enable-static --disable-shared --enable-extras=no --enable-strict=no --enable-tests=no --enable-samples=no --enable-dyload=no --enable-tools=no --with-data-packaging=archive
 
-make
+make VERBOSE=1
 make install
 popd
 


### PR DESCRIPTION
The iOS build (especially Boost) is quite a bit different than it is for Android.  I've refactored the build so that iOS and Android are more similar.  In this pull request:
- Android and iOS configure their Boost packages the same way and for the same packages
- Android and iOS build ICU with the same flags
- iOS builds Boost in the platform loop (like how Android does) rather than all in one go.  This greatly simplifies the build script, as all the lipo-ing can happen in the build-all script.  This also allows the Boost build to potentially use upstream libraries that have already been built (such as ICU).
- iOS Boost build now untars to the same place that Android does (which is just cleaner)
- iOS Boost now produces the same .a files as Android (libboost_xxx as well as the combined libboost.a)
