### PR TITLE
build fails for xcode 4.6

### DIFF
--- a/build-ios/build-GnuPG.sh
+++ b/build-ios/build-GnuPG.sh
@@ -65,11 +65,11 @@ fi
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 
-./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-zlib=${SDKROOT} --with-bzip2=${ROOTDIR} --enable-static --disable-shared
+./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-zlib=${BUILD_SDKROOT} --with-bzip2=${ROOTDIR} --enable-static --disable-shared
 mv "Makefile" "Makefile~"
 sed '/checks =/d' "Makefile~" > "Makefile"  # Patch Makefile to disable checks
 make

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -134,10 +134,10 @@ do
 	export ARCH="${ARCH}"
 
 	export DEVROOT="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
-	export SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${CSDK}.sdk"
-	if [ ! -d ${SDKROOT} ]
+	export BUILD_SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${CSDK}.sdk"
+	if [ ! -d ${BUILD_SDKROOT} ]
 	then
-		echo "WARNING! Unable to locate SDK for architecture ${ARCH}: ${SDKROOT}"
+		echo "WARNING! Unable to locate SDK for architecture ${ARCH}: ${BUILD_SDKROOT}"
 		continue
 	fi
 

--- a/build-ios/build-all.sh
+++ b/build-ios/build-all.sh
@@ -133,22 +133,22 @@ do
 	export PLATFORM="${PLATFORM}"
 	export ARCH="${ARCH}"
 
-	export DEVROOT="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
-	export BUILD_SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${CSDK}.sdk"
+	export BUILD_DEVROOT="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
+	export BUILD_SDKROOT="${BUILD_DEVROOT}/SDKs/${PLATFORM}${CSDK}.sdk"
 	if [ ! -d ${BUILD_SDKROOT} ]
 	then
 		echo "WARNING! Unable to locate SDK for architecture ${ARCH}: ${BUILD_SDKROOT}"
 		continue
 	fi
 
-	export CC="${DEVROOT}/usr/bin/gcc"
-	export LD="${DEVROOT}/usr/bin/ld"
-	export CXX="${DEVROOT}/usr/bin/g++"
-	export AR="${DEVROOT}/usr/bin/ar"
-	export AS="${DEVROOT}/usr/bin/as"
-	export NM="${DEVROOT}/usr/bin/nm"
-	export STRIP="${DEVROOT}/usr/bin/strip"
-	export RANLIB="${DEVROOT}/usr/bin/ranlib"
+	export CC="${BUILD_DEVROOT}/usr/bin/gcc"
+	export LD="${BUILD_DEVROOT}/usr/bin/ld"
+	export CXX="${BUILD_DEVROOT}/usr/bin/g++"
+	export AR="${BUILD_DEVROOT}/usr/bin/ar"
+	export AS="${BUILD_DEVROOT}/usr/bin/as"
+	export NM="${BUILD_DEVROOT}/usr/bin/nm"
+	export STRIP="${BUILD_DEVROOT}/usr/bin/strip"
+	export RANLIB="${BUILD_DEVROOT}/usr/bin/ranlib"
 
 	# Build minizip
 	${TOPDIR}/build-ios/build-minizip.sh > "${LOGPATH}-minizip.log"
@@ -224,7 +224,7 @@ find ${TMPDIR}/build/ios -name "libboost_*.*" -exec rm -f {} \;
 
 # Create Lipo Archives and Framework bundle
 
-DEVROOT=${DEVELOPER}/Platforms/iPhoneOS.platform/Developer
+BUILD_DEVROOT=${DEVELOPER}/Platforms/iPhoneOS.platform/Developer
 
 VERSION_TYPE=Release
 FRAMEWORK_NAME=CMOSS
@@ -261,7 +261,7 @@ for a in $(cat $BINDIR/libs | sort | uniq); do
 	done
 
 	echo Creating fat archive $BINDIR/lib/$a...
-	$DEVROOT/usr/bin/lipo -output "$BINDIR/lib/$a" -create -arch armv6 "$TMPDIR/build/ios/iPhoneOS-V6/lib/$a" -arch armv7 "$TMPDIR/build/ios/iPhoneOS-V7/lib/$a" -arch i386 "$TMPDIR/build/ios/iPhoneSimulator/lib/$a"
+	$BUILD_DEVROOT/usr/bin/lipo -output "$BINDIR/lib/$a" -create -arch armv6 "$TMPDIR/build/ios/iPhoneOS-V6/lib/$a" -arch armv7 "$TMPDIR/build/ios/iPhoneOS-V7/lib/$a" -arch i386 "$TMPDIR/build/ios/iPhoneSimulator/lib/$a"
 
 done
 rm -f $BINDIR/libs

--- a/build-ios/build-bzip2.sh
+++ b/build-ios/build-bzip2.sh
@@ -41,7 +41,7 @@ pushd "bzip2-${BZIP2_VERSION}"
 # Build
 export BIGFILES=-D_FILE_OFFSET_BITS=64
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-cURL.sh
+++ b/build-ios/build-cURL.sh
@@ -39,11 +39,11 @@ pushd "curl-${CURL_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 
-./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-zlib=${SDKROOT}/usr --with-ssl=${ROOTDIR} --with-libssh2=${ROOTDIR} --with-random=/dev/urandom --disable-shared --enable-static --disable-ipv6 --disable-manual --disable-verbose  # Work around curl tool not linking against static libssh2 by only building library and headers
+./configure --host=${ARCH}-apple-darwin --prefix=${ROOTDIR} --with-zlib=${BUILD_SDKROOT}/usr --with-ssl=${ROOTDIR} --with-libssh2=${ROOTDIR} --with-random=/dev/urandom --disable-shared --enable-static --disable-ipv6 --disable-manual --disable-verbose  # Work around curl tool not linking against static libssh2 by only building library and headers
 pushd "lib"
 make
 make install

--- a/build-ios/build-cares.sh
+++ b/build-ios/build-cares.sh
@@ -39,7 +39,7 @@ pushd "c-ares-${CARES_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-expat.sh
+++ b/build-ios/build-expat.sh
@@ -39,7 +39,7 @@ pushd "expat-${EXPAT_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-icu.sh
+++ b/build-ios/build-icu.sh
@@ -52,7 +52,7 @@ fi
 ICU_FLAGS="-I${TMPDIR}/icu/source/common/ -I${TMPDIR}/icu/source/tools/tzcode/"
 
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 ${ICU_FLAGS} -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 ${ICU_FLAGS} -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-libgcrypt.sh
+++ b/build-ios/build-libgcrypt.sh
@@ -65,7 +65,7 @@ fi
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-libgpg-error.sh
+++ b/build-ios/build-libgpg-error.sh
@@ -39,7 +39,7 @@ pushd "libgpg-error-${LIBGPG_ERROR_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-libgsasl.sh
+++ b/build-ios/build-libgsasl.sh
@@ -39,7 +39,7 @@ tar xvf "libgsasl-${LIBGSASL_VERSION}.tar.gz"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-libidn.sh
+++ b/build-ios/build-libidn.sh
@@ -40,7 +40,7 @@ pushd "libidn-${LIBIDN_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -isysroot ${SDKROOT} -miphoneos-version-min=2.2 ${ICU_FLAGS} -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 ${ICU_FLAGS} -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-libssh2.sh
+++ b/build-ios/build-libssh2.sh
@@ -39,7 +39,7 @@ pushd "libssh2-${LIBSSH2_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-minizip.sh
+++ b/build-ios/build-minizip.sh
@@ -44,7 +44,7 @@ cp -f ${TOPDIR}/build-ios/Makefile.minizip .
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib -lz -dynamiclib"
-export CFLAGS="-Os -D_FILE_OFFSET_BITS=64 -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -Dfopen64=fopen -Dfseeko64=fseeko -Dftello64=ftello"
+export CFLAGS="-Os -D_FILE_OFFSET_BITS=64 -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -Dfopen64=fopen -Dfseeko64=fseeko -Dftello64=ftello"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-openssl.sh
+++ b/build-ios/build-openssl.sh
@@ -39,7 +39,7 @@ pushd "openssl-${OPENSSL_VERSION}"
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -dynamiclib"
-export CFLAGS="-Os -D_DARWIN_C_SOURCE -UOPENSSL_BN_ASM_PART_WORDS -arch ${ARCH} -isysroot ${SDKROOT}"
+export CFLAGS="-Os -D_DARWIN_C_SOURCE -UOPENSSL_BN_ASM_PART_WORDS -arch ${ARCH} -isysroot ${BUILD_SDKROOT}"
 
 ./config no-shared no-asm no-krb5 no-gost zlib --openssldir=${ROOTDIR}
 

--- a/build-ios/build-pion.sh
+++ b/build-ios/build-pion.sh
@@ -42,7 +42,7 @@ pushd pion-${PION_VERSION}
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -fvisibility=hidden -fvisibility-inlines-hidden -fdata-sections"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -fvisibility=hidden -fvisibility-inlines-hidden -fdata-sections"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-soci.sh
+++ b/build-ios/build-soci.sh
@@ -43,7 +43,7 @@ cp -f ${TOPDIR}/build-ios/Makefile.soci-sqlite3 soci-${SOCI_VERSION}/backends/sq
 # Build
 export BIGFILES=-D_FILE_OFFSET_BITS=64
 export LDFLAGS="-Os -fvisibility=hidden -arch ${ARCH} -L${ROOTDIR}/lib"
-export CFLAGS="-Os -fvisibility=hidden -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
+export CFLAGS="-Os -fvisibility=hidden -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-sqlcipher.sh
+++ b/build-ios/build-sqlcipher.sh
@@ -42,7 +42,7 @@ pushd sqlcipher-${SQLCIPHER_VERSION}
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -L${ROOTDIR}/lib"
-export CFLAGS="-Os -D_FILE_OFFSET_BITS=64 -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -DSQLITE_HAS_CODEC"
+export CFLAGS="-Os -D_FILE_OFFSET_BITS=64 -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -DSQLITE_HAS_CODEC"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-tinyxml.sh
+++ b/build-ios/build-tinyxml.sh
@@ -42,7 +42,7 @@ cp ${TOPDIR}/build-ios/Makefile.tinyxml tinyxml/Makefile
 pushd "tinyxml"
 BIGFILES=-D_FILE_OFFSET_BITS=64
 export LDFLAGS="-Os -arch ${ARCH} -Wl,-dead_strip -Wno-unknown-pragmas -Wno-format -miphoneos-version-min=2.2 -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include -g ${BIGFILES}"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 

--- a/build-ios/build-yajl.sh
+++ b/build-ios/build-yajl.sh
@@ -39,7 +39,7 @@ pushd lloyd-yajl-*
 
 # Build
 export LDFLAGS="-Os -arch ${ARCH} -L${ROOTDIR}/lib"
-export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
+export CFLAGS="-Os -arch ${ARCH} -pipe -no-cpp-precomp -isysroot ${BUILD_SDKROOT} -miphoneos-version-min=2.2 -I${ROOTDIR}/include"
 export CPPFLAGS="${CFLAGS}"
 export CXXFLAGS="${CFLAGS}"
 


### PR DESCRIPTION
When building on a machine with XCode 4.6, the libgpg-error-1.10 build fails:

```
configure: WARNING: If you wanted to set the --build type, don't use --host.
    If a cross compiler is detected then cross compile mode will be used.
configure: WARNING: using cross tools not prefixed with host triplet
In file included from ./mkerrcodes.c:24:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/usr/include/stdio.h:67:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/usr/include/_types.h:27:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/usr/include/sys/_types.h:33:
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/usr/include/machine/_types.h:32:10: fatal error: 'i386/_types.h' file not found
#include "i386/_types.h"
         ^
1 error generated.
make[2]: *** [mkerrcodes] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

It took some doing, but I figured out that the `SDKROOT` environment variable set by build-all.sh screws up something in the configure script (but only with XCode 4.6).  Changing it to something else (for example, `BUILD_SDKROOT`) fixes the problem.

This pull request does that.
