### PR TITLE
allow ANDROID_API_LEVEL/ARM_TARGET to be overridden

### DIFF
--- a/build-droid/build-all.sh
+++ b/build-droid/build-all.sh
@@ -87,8 +87,15 @@ mkdir -p $TMPDIR
 
 pushd $TMPDIR
 
-export ANDROID_API_LEVEL="14"
-export ARM_TARGET="armv7"
+if [ -z $ANDROID_API_LEVEL ]
+then
+    export ANDROID_API_LEVEL="14"
+fi
+
+if [ -z $ARM_TARGET ]
+then
+    export ARM_TARGET="armv7"
+fi
 
 if [ -z $TOOLCHAIN_VERSION ]
 then


### PR DESCRIPTION
The `build-droid/build-all.sh` script should allow for overriding ANDROID_API_LEVEL/ARM_TARGET.  In particular, being able to specify the api level means that someone could target older android versions than the default '14'.
